### PR TITLE
Allow button position to be set via data attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfactory-disclosure",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "A jQuery plugin for enhancement of predefined markup with accessible and keyboard-enabled reveal/hide functionality.",
   "repository": {
     "type": "git",

--- a/wf.disclosure.js
+++ b/wf.disclosure.js
@@ -15,7 +15,7 @@
  * - eigene Button-Texte können in Templates via data-Attribut übergeben werden, z.B. so:
  *   <div class="wf-disclosure js-disclosure" data-text-disclose="{{ 'akkordeon.mehrLesen'|trans|striptags }}" data-text-hide="{{ 'akkordeon.wenigerLesen' |trans|striptags }}">
  *   Wichtig: in mehrsprachigen Projekten am besten mit Messages arbeiten!
- *
+ * - die Position des Buttons (vor oder nach dem ausklappenden Panel) kann via `data-button-position-below` als boolean übergeben werden.
  * - Das Plugin unterstützt eine Ausfahranimation via CSS-Transition der max-height Eigenschaft mit Berechnung und
  *   Setzen der ausgeklappten max-height, wenn die Option useInlineMaxHeight übergeben wird (default: false)
  *

--- a/wf.disclosure.js
+++ b/wf.disclosure.js
@@ -1,5 +1,5 @@
 /**
- * disclosure.js
+ * wf.disclosure.js
  * @file jQuery Plugin zum Anreichern von vordefiniertem Markup mit Aus- bzw. Einklappfunktion
  * (barrierearm und inkl. Tastaturunterstützung)
  *
@@ -86,17 +86,11 @@
             $disclosures.each(function (index, disclosure) {
                 var $disclosure = $(disclosure);
                 var $panel = $disclosure.find(settings.disclosurePanel);
-                var buttonTextDisclose = settings.buttonTextDisclose;
-                var buttonTextHide = settings.buttonTextHide;
 
-                // Nutze custom Buttontext soweit definiert
-                if ($disclosure.data('text-disclose')) {
-                    buttonTextDisclose = $disclosure.data('text-disclose');
-                }
-
-                if ($disclosure.data('text-hide')) {
-                    buttonTextHide = $disclosure.data('text-hide');
-                }
+                // Werte optionale data-Attribute widget-spezifisch aus
+                var buttonTextDisclose = $disclosure.data('text-disclose') ?? settings.buttonTextDisclose;
+                var buttonTextHide = $disclosure.data('text-hide') ?? settings.buttonTextHide;
+                var buttonPositionBelow = $disclosure.data('button-position-below') ?? settings.buttonPositionBelow;
 
                 var $button = $('<button type="button" class="' + settings.buttonStylingClass + '">' + buttonTextDisclose + '</button>');
 
@@ -122,7 +116,7 @@
                 $panel.attr('aria-labelledby', buttonId);
 
                 // Setze Button ins DOM ein
-                if (settings.buttonPositionBelow) {
+                if (buttonPositionBelow) {
                     $disclosure.append($button);
                 } else {
                     $button.insertBefore($panel);


### PR DESCRIPTION
For BC reasons, the button's default position remains below the disclosable panel. 

This PR also adds some slight refactoring and makes use of the null coalescing operator while assigning widget-specific variables.
