### PR TITLE
Update default button position for accessible DOM order

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,10 @@
+# Upgrading
+
+## 4.0.0
+
+- The default for `buttonPositionBelow` is now `false` which means the disclosed content will appear below the button. The new default produces the DOM order that is accessible with regard to WCAG 1.3.2 and 3.2.2.
+
+## 3.0.0
+
+- webfactory-disclosure no longer requires jQuery
+- ESM Module syntax is supported

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfactory-disclosure",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "A plugin for enhancement of predefined markup with accessible and keyboard-enabled reveal/hide functionality.",
   "repository": {
     "type": "git",

--- a/wf.disclosure.js
+++ b/wf.disclosure.js
@@ -55,7 +55,7 @@ export function wfDisclosure(options = {}) {
         buttonStylingClass: 'wf-disclosure__button',
         buttonTextDisclose: 'mehr lesen',
         buttonTextHide: 'weniger lesen',
-        buttonPositionBelow: true,
+        buttonPositionBelow: false, // Danger Zone: probable failure of WCAG 1.3.2 and 3.2.2 if the trigger is positioned below the disclosed content
         animateMaxHeight: false
     };
 


### PR DESCRIPTION
The default for `buttonPositionBelow` is now `false` which means the disclosed content will appear below the button. The new default produces the DOM order that is accessible with regard to WCAG 1.3.2 and 3.2.2.
